### PR TITLE
[FABB-151] Remove delayed_commits=true

### DIFF
--- a/images/couchdb/20-fabric-default.ini
+++ b/images/couchdb/20-fabric-default.ini
@@ -12,8 +12,7 @@ uri_file = ./data/couch.uri
 ; concurrency may need to increase this setting.
 max_dbs_open = 8000
 
-; allow delayed commits since peer manages savepoints and flushing to disk
-delayed_commits = true
+; delayed_commits must remain at the CouchDB default 'false' to ensure data is flushed to disk upon every write
 
 ; Specify the maximum document body size
 max_document_size = 4294967296


### PR DESCRIPTION
Since ensure_full_commit API in CouchDB doesn't work as documented in CouchDB v2.x,
Fabric requires delayed_commits to be false.
'false' is the default in CouchDB, therefore this commit simply removes the
override of delayed_commits=true.
Using the default value of 'false' ensures that writes are synced to disk.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>