### PR TITLE
Bump Go Version and Prepare for Next Release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 
 DOCKER_NS ?= hyperledger
 BASENAME ?= $(DOCKER_NS)/fabric
-VERSION ?= 0.4.21
+VERSION ?= 0.4.22
 
 ARCH=$(shell go env GOARCH)
 DOCKER_TAG ?= $(ARCH)-$(VERSION)

--- a/ci/azure-pipelines-release.yml
+++ b/ci/azure-pipelines-release.yml
@@ -11,7 +11,7 @@ variables:
   - name: GOPATH
     value: $(Agent.BuildDirectory)/go
   - name: GOVER
-    value: 1.13.8
+    value: 1.13.12
 
 stages:
   - stage: BuildAndPushDockerImages

--- a/scripts/common/setup.sh
+++ b/scripts/common/setup.sh
@@ -32,7 +32,7 @@ export GOROOT="/opt/go"
 mkdir -p $GOPATH
 ARCH=`uname -m | sed 's|i686|386|' | sed 's|x86_64|amd64|'`
 BINTARGETS="x86_64 ppc64le s390x"
-GO_VER=1.13.8
+GO_VER=1.13.12
 
 # Install Golang binary if found in BINTARGETS
 if echo $BINTARGETS | grep -q `uname -m`; then


### PR DESCRIPTION
Contains two commits:

First: Bumps the Go version to 1.13.12
Second: Bumps the Release version as we will release on the Go bump