### PR TITLE
Bump Go to 1.14.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 
 DOCKER_NS ?= hyperledger
 BASENAME ?= $(DOCKER_NS)/fabric
-VERSION ?= 0.4.21
+VERSION ?= 0.4.22
 
 ARCH=$(shell go env GOARCH)
 DOCKER_TAG ?= $(ARCH)-$(VERSION)

--- a/ci/azure-pipelines-release.yml
+++ b/ci/azure-pipelines-release.yml
@@ -11,7 +11,7 @@ variables:
   - name: GOPATH
     value: $(Agent.BuildDirectory)/go
   - name: GOVER
-    value: 1.13.12
+    value: 1.14.12
 
 stages:
   - stage: BuildAndPushDockerImages

--- a/scripts/common/setup.sh
+++ b/scripts/common/setup.sh
@@ -32,7 +32,7 @@ export GOROOT="/opt/go"
 mkdir -p $GOPATH
 ARCH=`uname -m | sed 's|i686|386|' | sed 's|x86_64|amd64|'`
 BINTARGETS="x86_64 ppc64le s390x"
-GO_VER=1.13.12
+GO_VER=1.14.12
 
 # Install Golang binary if found in BINTARGETS
 if echo $BINTARGETS | grep -q `uname -m`; then


### PR DESCRIPTION
Go 1.13 is no longer supported and there are several
critical bug fixes in the Go 1.14 stream. Bumping
Go to the 1.14 stream to get back on a supported release
as well as pick up these fixes.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>