### PR TITLE
Archive Fabric Baseimage

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,13 +1,13 @@
 repository:
   name: fabric-baseimage
-  description: null
+  description: Deprecated Fabric Base Images
   homepage: https://wiki.hyperledger.org/display/fabric
   default_branch: master
   has_downloads: true
   has_issues: false
   has_projects: false
   has_wiki: false
-  archived: false
+  archived: true
   private: false
   allow_squash_merge: true
   allow_merge_commit: false


### PR DESCRIPTION
It has been over two years since 1.4 LTS was declared.

https://www.hyperledger.org/blog/2019/01/10/introducing-hyperledger-fabric-1-4-lts

Signed-off-by: Ry Jones <ry@linux.com>